### PR TITLE
Update `props` example in queries.md

### DIFF
--- a/source/queries.md
+++ b/source/queries.md
@@ -195,7 +195,7 @@ const CurrentUserForLayout = gql`
 const ProfileWithData = graphql(CurrentUserForLayout, {
   // ownProps are the props that are passed into the `ProfileWithData`
   // when it is used by a parent component
-  props({ ownProps, data: { loading, currentUser, refetch } }) => ({
+  props: ({ ownProps, data: { loading, currentUser, refetch } }) => ({
     userLoading: loading,
     user: currentUser,
     refetchUser: refetch,


### PR DESCRIPTION
Update the code example syntax for using `props` in `graphql` to map props. The example as given errors.