### PR TITLE
Fix: the query options example is misleading

### DIFF
--- a/source/receiving-updates.md
+++ b/source/receiving-updates.md
@@ -60,9 +60,7 @@ Continuing with our refetch example, we can add a polling interval simply by add
 
 ```javascript
 const FeedWithData = graphql(FeedEntries, {
-  options: {
-    return { pollInterval: 20000 };
-  },
+  options: { pollInterval: 20000 },
 })(Feed);
 ```
 


### PR DESCRIPTION
Note: the example here was misleading:
```javascript
const FeedWithData = graphql(FeedEntries, {
  options: {
    return { pollInterval: 20000 };
  },
})(Feed);
```

I believe that it was supposed to be either a lambda that returns an object, or just a plain object without the `return` so I updated it to

```javascript
const FeedWithData = graphql(FeedEntries, {
  options: { pollInterval: 20000 },
})(Feed);
```