### PR TITLE
react-native.md: link to the "React guide"

### DIFF
--- a/source/react-native.md
+++ b/source/react-native.md
@@ -28,7 +28,7 @@ const App = () => (
 AppRegistry.registerComponent('MyApplication', () => App);
 ```
 
-If you are new to using Apollo with React, you should probably read this guide from [the beginning](index.html).
+If you are new to using Apollo with React, you should probably read the [React guide](index.html).
 
 <h2 id="examples">Examples</h2>
 


### PR DESCRIPTION
With the idea that a common way people get to this page is clicking "React Native":

![image](https://cloud.githubusercontent.com/assets/251288/19414098/73a348c4-9310-11e6-8e90-d1061ef5adea.png)

And they don't know they're already technically inside the React guide