### PR TITLE
subscribeToMore accepts document key for the query

### DIFF
--- a/source/receiving-updates.md
+++ b/source/receiving-updates.md
@@ -100,7 +100,7 @@ class Feed extends Component {
       }
       const entryIds = newProps.data.feed.map(item => item.id);
       this.subscription = newProps.data.subscribeToMore({
-        query: SUBSCRIPTION_QUERY,
+        document: SUBSCRIPTION_QUERY,
         variables: { entryIds },
 
         // this is where the magic happens.


### PR DESCRIPTION
Figured out looking at the [test](https://github.com/apollostack/apollo-client/blob/master/test/subscribeToMore.ts#L69) that subscribeToMore accepts the subscription query via the `document` key.