### PR TITLE
Updated react fragment docs

### DIFF
--- a/source/fragments.md
+++ b/source/fragments.md
@@ -35,7 +35,7 @@ To do so, we can simply share a fragment describing the fields we need for a com
 import gql from 'graphql-tag';
 
 CommentsPage.fragments = {
-  comment: gql`
+  comment: `
     fragment CommentsPageComment on Comment {
       id
       postedBy {
@@ -49,7 +49,7 @@ CommentsPage.fragments = {
 };
 ```
 
-We put the fragment on `CommentsPage.fragments.comment` by convention, and use the familiar `gql` helper to create it.
+We put the fragment on `CommentsPage.fragments.comment` by convention.
 
 When it's time to embed the fragment in a query, we simply use the `...Name` syntax in our GraphQL, and pass the fragment object into our `graphql` HOC:
 


### PR DESCRIPTION
Using the gql helper in the fragment does not work because graphql-tag will compile the graphql to an object. This will result a query string like this:
```js
FeedEntry.fragments = {
  entry: gql`
    fragment FeedEntry on Entry {
      commentCount
      repository {
        full_name
        html_url
        owner {
          avatar_url
        }
      }
      ...VoteButtons
      ...RepoInfo
    }
    [object Object]
    [object Object]
  `,
};
```

Since this is not valid graphql you get an syntax error.