### PR TITLE
Remove unneeded backtick in cache-updates.md

### DIFF
--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -101,7 +101,7 @@ const client = new ApolloClient({
       networkInterface,
       customResolvers: {
         Query: {
-          book: (_, args) => toIdValue(dataIdFromObject({ __typename: 'book', id: args['id']` })),
+          book: (_, args) => toIdValue(dataIdFromObject({ __typename: 'book', id: args['id'] })),
         },
       },
       dataIdFromObject,


### PR DESCRIPTION
Probably just a typo. 
Also, I'm not sure where the ```dataIdFromObject``` should be imported from.