### PR TITLE
Pass an object rather than a string to prevent warning

### DIFF
--- a/source/auth.md
+++ b/source/auth.md
@@ -32,7 +32,9 @@ Another common way to identify yourself when using HTTP is to send along an auth
 ```js
 import ApolloClient, { createNetworkInterface } from 'apollo-client';
 
-const networkInterface = createNetworkInterface('/graphql');
+const networkInterface = createNetworkInterface({
+  uri: '/graphql',
+});
 
 networkInterface.use([{
   applyMiddleware(req, next) {


### PR DESCRIPTION
Passing a string results in the warning:

"Passing the URI as the first argument to createNetworkInterface is deprecated as of Apollo Client 0.5. Please pass it as the "uri" property of the network interface options."